### PR TITLE
MOSIP-27529

### DIFF
--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/clientcrypto/service/impl/ClientCryptoFacade.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/clientcrypto/service/impl/ClientCryptoFacade.java
@@ -168,6 +168,7 @@ public class ClientCryptoFacade {
                     dataToDecrypt.length);
             return cryptoCore.symmetricDecrypt(secretKey, cipher, iv, aad);
         } catch (Throwable t) {
+            LOGGER.error("Failed to decrypt the data due to : ", t.getMessage());
             //1.1.4.4 backward compatibility code, for IV_LENGTH = 16 and AAD_LENGTH = 12;
             byte[] iv = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength, symmetricKeyLength + 16);
             byte[] aad = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength + 16, symmetricKeyLength + 16 + 12);

--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/clientcrypto/service/impl/ClientCryptoFacade.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/clientcrypto/service/impl/ClientCryptoFacade.java
@@ -159,13 +159,22 @@ public class ClientCryptoFacade {
     public byte[] decrypt(byte[] dataToDecrypt) {
         byte[] encryptedSecretKey = Arrays.copyOfRange(dataToDecrypt, 0, symmetricKeyLength);
         byte[] secretKeyBytes =  Objects.requireNonNull(getClientSecurity()).asymmetricDecrypt(encryptedSecretKey);
-        byte[] iv = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength, symmetricKeyLength+ivLength);
-        byte[] aad = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength + ivLength, symmetricKeyLength+ivLength+aadLength);
-        byte[] cipher = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength + ivLength + aadLength,
-                dataToDecrypt.length);
-
         SecretKey secretKey = new SecretKeySpec(secretKeyBytes, "AES");
-        return cryptoCore.symmetricDecrypt(secretKey, cipher, iv, aad);
+
+        try {
+            byte[] iv = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength, symmetricKeyLength + ivLength);
+            byte[] aad = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength + ivLength, symmetricKeyLength + ivLength + aadLength);
+            byte[] cipher = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength + ivLength + aadLength,
+                    dataToDecrypt.length);
+            return cryptoCore.symmetricDecrypt(secretKey, cipher, iv, aad);
+        } catch (Throwable t) {
+            //1.1.4.4 backward compatibility code, for IV_LENGTH = 16 and AAD_LENGTH = 12;
+            byte[] iv = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength, symmetricKeyLength + 16);
+            byte[] aad = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength + 16, symmetricKeyLength + 16 + 12);
+            byte[] cipher = Arrays.copyOfRange(dataToDecrypt, symmetricKeyLength + 16 + 12,
+                    dataToDecrypt.length);
+            return cryptoCore.symmetricDecrypt(secretKey, cipher, iv, aad);
+        }
     }
 
     public static byte[] generateRandomBytes(int length) {


### PR DESCRIPTION
1.1.4.4 key manager used IV_length as 16 and aad_length as 12, but after  1.2.0* Default IV length was updated to 12 and aad length as 32. Due to this upgrade of reg-client from 1.1.4* to 1.2.0* is not successful. 
To solve this we have provided a fix to try decryption with older lengths only on failure.