### PR TITLE
[INJICERT-657] (nitpick): update default JWT algo

### DIFF
--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/signature/service/impl/SignatureServiceImpl.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/signature/service/impl/SignatureServiceImpl.java
@@ -654,7 +654,7 @@ public class SignatureServiceImpl implements SignatureService, SignatureServicev
 			referenceId = signRefid;
 		}
 		String signAlgorithm = SignatureUtil.isDataValid(signatureReq.getSignAlgorithm()) ?
-				signatureReq.getSignAlgorithm(): SignatureConstant.ED25519_ALGORITHM;
+				signatureReq.getSignAlgorithm(): SignatureConstant.JWS_EDDSA_SIGN_ALGO_CONST;
 
 		SignatureCertificate certificateResponse = keymanagerService.getSignatureCertificate(applicationId,
 				Optional.of(referenceId), timestamp);


### PR DESCRIPTION
# Fixes

- For V2 signing, the default sign algorithm is Ed25519(which is a key type) but the JSON Web Algorithm is EdDSA

Further improvement:

- More business logic can be added to SignatureUtil to enhance the error handling scenarios of giving the invalid algorithm