### PR TITLE
MOSIP-44825

### DIFF
--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/cryptomanager/util/CryptomanagerUtils.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/cryptomanager/util/CryptomanagerUtils.java
@@ -64,6 +64,12 @@ public class CryptomanagerUtils {
 
 	private static ObjectMapper mapper = JsonMapper.builder().addModule(new AfterburnerModule()).build();
 
+	// Single shared instance seeded once at JVM startup. SecureRandom.nextBytes()
+	// is thread-safe (synchronized internally). Static so it survives @RefreshScope
+	// bean recreation and avoids re-seeding overhead (and potential entropy
+	// starvation) at 150 new instances/sec under load.
+	private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
 	/** The Constant UTC_DATETIME_PATTERN. */
 	private static final String UTC_DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
@@ -235,8 +241,7 @@ public class CryptomanagerUtils {
 
 	public byte[] generateRandomBytes(int size) {
 		byte[] randomBytes = new byte[size];
-		SecureRandom secureRandom = new SecureRandom();
-		secureRandom.nextBytes(randomBytes);
+		SECURE_RANDOM.nextBytes(randomBytes);
 		return randomBytes;
 	}
 

--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/keymanagerservice/config/ReqResFilter.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/keymanagerservice/config/ReqResFilter.java
@@ -12,7 +12,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.web.util.ContentCachingRequestWrapper;
-import org.springframework.web.util.ContentCachingResponseWrapper;
 
 /**
  * This class is for input logging of all parameters in HTTP requests
@@ -32,18 +31,17 @@ public class ReqResFilter implements Filter {
 			throws IOException, ServletException {
 		HttpServletRequest httpServletRequest = (HttpServletRequest) request;
 		HttpServletResponse httpServletResponse = (HttpServletResponse) response;
-		ContentCachingRequestWrapper requestWrapper = null;
-		ContentCachingResponseWrapper responseWrapper = null;
-
 		// Default processing for url ends with .stream
 		if (httpServletRequest.getRequestURI().endsWith(".stream")) {
 			chain.doFilter(request, response);
 			return;
 		}
-		requestWrapper = new ContentCachingRequestWrapper(httpServletRequest);
-		responseWrapper = new ContentCachingResponseWrapper(httpServletResponse);
-		chain.doFilter(requestWrapper, responseWrapper);
-		responseWrapper.copyBodyToResponse();
+		// Cache only the first 4096 bytes — sufficient for JSON metadata (id, version)
+		// without buffering the full encrypted payload in memory at high RPS.
+		ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(httpServletRequest, 4096);
+		// Pass the actual response directly; response body buffering is not required
+		// since ResponseBodyAdviceConfig only reads request metadata, not the response.
+		chain.doFilter(requestWrapper, httpServletResponse);
 
 	}
 

--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/keymanagerservice/config/ResponseBodyAdviceConfig.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/keymanagerservice/config/ResponseBodyAdviceConfig.java
@@ -1,5 +1,6 @@
 package io.mosip.kernel.keymanagerservice.config;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 
@@ -14,14 +15,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
-import io.mosip.kernel.core.http.RequestWrapper;
 import io.mosip.kernel.core.http.ResponseFilter;
 import io.mosip.kernel.core.http.ResponseWrapper;
 import io.mosip.kernel.core.logger.spi.Logger;
-import io.mosip.kernel.core.util.EmptyCheckUtils;
 
 /**
  * @author Bal Vikash Sharma
@@ -35,6 +36,14 @@ public class ResponseBodyAdviceConfig implements ResponseBodyAdvice<ResponseWrap
 
 	@Autowired
 	private ObjectMapper objectMapper;
+
+	@PostConstruct
+	public void init() {
+		// Register JavaTimeModule once at startup on the shared singleton ObjectMapper.
+		// Registering per-request (150 RPS) creates object churn and mutates shared
+		// state concurrently — both corrected here.
+		objectMapper.registerModule(new JavaTimeModule());
+	}
 
 	/*
 	 * (non-Javadoc)
@@ -63,27 +72,21 @@ public class ResponseBodyAdviceConfig implements ResponseBodyAdvice<ResponseWrap
 			MediaType selectedContentType, Class<? extends HttpMessageConverter<?>> selectedConverterType,
 			ServerHttpRequest request, ServerHttpResponse response) {
 
-		RequestWrapper<?> requestWrapper = null;
-		String requestBody = null;
-
 		try {
 			HttpServletRequest httpServletRequest = ((ServletServerHttpRequest) request).getServletRequest();
 
+			byte[] cachedBody = null;
 			if (httpServletRequest instanceof ContentCachingRequestWrapper) {
-				requestBody = new String(((ContentCachingRequestWrapper) httpServletRequest).getContentAsByteArray());
+				cachedBody = ((ContentCachingRequestWrapper) httpServletRequest).getContentAsByteArray();
 			} else if (httpServletRequest instanceof HttpServletRequestWrapper
 					&& ((HttpServletRequestWrapper) httpServletRequest)
-							.getRequest() instanceof ContentCachingRequestWrapper) {
-				requestBody = new String(
-						((ContentCachingRequestWrapper) ((HttpServletRequestWrapper) httpServletRequest).getRequest())
-								.getContentAsByteArray());
+					.getRequest() instanceof ContentCachingRequestWrapper) {
+				cachedBody = ((ContentCachingRequestWrapper) ((HttpServletRequestWrapper) httpServletRequest).getRequest())
+						.getContentAsByteArray();
 			}
 
-			objectMapper.registerModule(new JavaTimeModule());
-			if (!EmptyCheckUtils.isNullEmpty(requestBody)) {
-				requestWrapper = objectMapper.readValue(requestBody, RequestWrapper.class);
-				body.setId(requestWrapper.getId());
-				body.setVersion(requestWrapper.getVersion());
+			if (cachedBody != null && cachedBody.length > 0) {
+				extractAndSetIdVersion(body, cachedBody);
 			}
 			body.setErrors(null);
 			return body;
@@ -91,6 +94,44 @@ public class ResponseBodyAdviceConfig implements ResponseBodyAdvice<ResponseWrap
 			mosipLogger.error("", "", "", e.getMessage());
 		}
 		return body;
+	}
+
+	/**
+	 * Extracts only the top-level "id" and "version" fields from the cached
+	 * (possibly truncated) request body using a streaming JSON parser.
+	 *
+	 * ReqResFilter caps the cached body at 4096 bytes. A full ObjectMapper.readValue()
+	 * fails with JsonEOFException when the encrypted "data" field spans the truncation
+	 * boundary (column 4097). The streaming parser reads token-by-token and stops as
+	 * soon as both fields are found — which happens within the first ~100 bytes since
+	 * "id" and "version" are always the first two fields in the MOSIP RequestWrapper
+	 * JSON envelope — long before any truncation can occur.
+	 */
+	private void extractAndSetIdVersion(ResponseWrapper<?> body, byte[] cachedBody) {
+		try (JsonParser parser = objectMapper.getFactory().createParser(cachedBody)) {
+			String id = null;
+			String version = null;
+			JsonToken token;
+			while ((token = parser.nextToken()) != null) {
+				if (id != null && version != null) break;
+				if (token == JsonToken.FIELD_NAME) {
+					String fieldName = parser.getCurrentName();
+					token = parser.nextToken();
+					if ("id".equals(fieldName) && token == JsonToken.VALUE_STRING) {
+						id = parser.getText();
+					} else if ("version".equals(fieldName) && token == JsonToken.VALUE_STRING) {
+						version = parser.getText();
+					} else if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+						if (id != null && version != null) break;
+						parser.skipChildren();
+					}
+				}
+			}
+			if (id != null) body.setId(id);
+			if (version != null) body.setVersion(version);
+		} catch (Exception e) {
+			mosipLogger.debug("", "", "", "Could not extract id/version from cached request body: " + e.getMessage());
+		}
 	}
 
 }

--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/keymanagerservice/exception/KeymanagerExceptionHandler.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/keymanagerservice/exception/KeymanagerExceptionHandler.java
@@ -1,8 +1,8 @@
 /*
- * 
- * 
- * 
- * 
+ *
+ *
+ *
+ *
  */
 package io.mosip.kernel.keymanagerservice.exception;
 
@@ -12,9 +12,11 @@ import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -44,7 +46,6 @@ import io.mosip.kernel.core.keymanager.exception.KeystoreProcessingException;
 import io.mosip.kernel.core.signatureutil.exception.ParseResponseException;
 import io.mosip.kernel.core.signatureutil.exception.SignatureUtilClientException;
 import io.mosip.kernel.core.signatureutil.exception.SignatureUtilException;
-import io.mosip.kernel.core.util.EmptyCheckUtils;
 import io.mosip.kernel.cryptomanager.constant.CryptomanagerErrorCode;
 import io.mosip.kernel.cryptomanager.exception.CryptoManagerSerivceException;
 import io.mosip.kernel.keymanagerservice.constant.KeymanagerConstant;
@@ -72,9 +73,17 @@ public class KeymanagerExceptionHandler {
 	@Autowired
 	private ObjectMapper objectMapper;
 
+	@PostConstruct
+	public void init() {
+		// Register JavaTimeModule once at startup. The original code called
+		// registerModule() inside setErrors() which runs on every exception path,
+		// mutating the shared ObjectMapper bean concurrently and creating garbage.
+		objectMapper.registerModule(new JavaTimeModule());
+	}
+
 	@ExceptionHandler(NullDataException.class)
 	public ResponseEntity<ResponseWrapper<ServiceError>> nullDataException(HttpServletRequest httpServletRequest,
-			final NullDataException e) throws IOException {
+																		   final NullDataException e) throws IOException {
 		ExceptionUtils.logRootCause(e);
 		return new ResponseEntity<>(
 				getErrorResponse(httpServletRequest, e.getErrorCode(), e.getErrorText(), HttpStatus.OK), HttpStatus.OK);
@@ -367,17 +376,44 @@ public class KeymanagerExceptionHandler {
 	private ResponseWrapper<ServiceError> setErrors(HttpServletRequest httpServletRequest) throws IOException {
 		ResponseWrapper<ServiceError> responseWrapper = new ResponseWrapper<>();
 		responseWrapper.setResponsetime(LocalDateTime.now(ZoneId.of("UTC")));
-		String requestBody = null;
+
+		byte[] cachedBody = null;
 		if (httpServletRequest instanceof ContentCachingRequestWrapper) {
-			requestBody = new String(((ContentCachingRequestWrapper) httpServletRequest).getContentAsByteArray());
+			cachedBody = ((ContentCachingRequestWrapper) httpServletRequest).getContentAsByteArray();
 		}
-		if (EmptyCheckUtils.isNullEmpty(requestBody)) {
+		if (cachedBody == null || cachedBody.length == 0) {
 			return responseWrapper;
 		}
-		objectMapper.registerModule(new JavaTimeModule());
-		JsonNode reqNode = objectMapper.readTree(requestBody);
-		responseWrapper.setId(reqNode.path("id").asText());
-		responseWrapper.setVersion(reqNode.path("version").asText());
+
+		// Use a streaming JSON parser to extract only the top-level "id" and "version"
+		// fields. The cached body is capped at 4096 bytes (ReqResFilter) so a full
+		// readTree() fails with JsonEOFException when the encrypted "data" field
+		// crosses the truncation boundary. The streaming parser stops as soon as both
+		// fields are found — within the first ~100 bytes — before any truncation.
+		try (JsonParser parser = objectMapper.getFactory().createParser(cachedBody)) {
+			String id = null;
+			String version = null;
+			JsonToken token;
+			while ((token = parser.nextToken()) != null) {
+				if (id != null && version != null) break;
+				if (token == JsonToken.FIELD_NAME) {
+					String fieldName = parser.getCurrentName();
+					token = parser.nextToken();
+					if ("id".equals(fieldName) && token == JsonToken.VALUE_STRING) {
+						id = parser.getText();
+					} else if ("version".equals(fieldName) && token == JsonToken.VALUE_STRING) {
+						version = parser.getText();
+					} else if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+						if (id != null && version != null) break;
+						parser.skipChildren();
+					}
+				}
+			}
+			if (id != null) responseWrapper.setId(id);
+			if (version != null) responseWrapper.setVersion(version);
+		} catch (Exception e) {
+			// Best-effort: truncated or malformed body won't affect error response structure
+		}
 		return responseWrapper;
 	}
 	

--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/keymanagerservice/helper/PrivateKeyDecryptorHelper.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/keymanagerservice/helper/PrivateKeyDecryptorHelper.java
@@ -8,11 +8,15 @@ import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
+import jakarta.annotation.PostConstruct;
+
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import io.mosip.kernel.core.crypto.exception.InvalidDataException;
@@ -43,9 +47,29 @@ public class PrivateKeyDecryptorHelper {
 
     private static final Logger LOGGER = KeymanagerLogger.getLogger(PrivateKeyDecryptorHelper.class);
 
-    private Map<String, io.mosip.kernel.keymanagerservice.entity.KeyStore> cacheKeyStore = new ConcurrentHashMap<>();
+	/**
+	 * Holds the DB KeyStore entry and its resolved referenceId together so that
+	 * both are always evicted atomically. Using two separate maps would allow
+	 * LRU eviction to evict one without the other, causing spurious
+	 * APP_ID_REFERENCE_ID_NOT_MATCHING exceptions.
+	 */
+	private static final class CacheEntry {
+		final KeyStore keyStore;
+		final String refId;
+		CacheEntry(KeyStore keyStore, String refId) {
+			this.keyStore = keyStore;
+			this.refId = refId;
+		}
+	}
 
-	private Map<String, String> cacheReferenceIds = new ConcurrentHashMap<>();
+	// Replaces the previous unbounded ConcurrentHashMaps (cacheKeyStore +
+	// cacheReferenceIds). Bounded by entryCapacity so memory does not grow
+	// indefinitely as new partner certificates are registered over time.
+	private Cache<String, CacheEntry> cacheDecryptData = null;
+
+	// Reuses the same property as keyAliasCache for consistent cache lifecycle.
+	@Value("${mosip.kernel.keymanager.key.cache.expire.inMins:1440}")
+	private long cacheExpireInMins;
 
     /**
 	 * Utility to generate Metadata
@@ -59,45 +83,55 @@ public class PrivateKeyDecryptorHelper {
     @Autowired
 	private ECKeyStore keyStore;
 
-    public KeyStore getDBKeyStoreData (String certThumbprintHex, String applicationId, String referenceId) {
+	@PostConstruct
+	public void init() {
+		cacheDecryptData = new Cache2kBuilder<String, CacheEntry>() {}
+				// hashCode suffix prevents name collision in test contexts where the Spring
+				// context is reloaded multiple times within the same JVM.
+				.name("privateKeyDecryptorData-" + this.hashCode())
+				.expireAfterWrite(cacheExpireInMins, TimeUnit.MINUTES)
+				// 1000 entries covers large MOSIP deployments with many partner certificates
+				// while bounding the heap footprint (~3-5 KB per entry × 1000 = ~3-5 MB max).
+				.entryCapacity(1000)
+				.build();
+	}
 
-        KeyStore dbKeyStore = cacheKeyStore.getOrDefault(certThumbprintHex, null);
+	public KeyStore getDBKeyStoreData (String certThumbprintHex, String applicationId, String referenceId) {
 
 		String appIdRefIdKey = applicationId + KeymanagerConstant.HYPHEN + referenceId;
-		String compMasterKeyRefId = applicationId + KeymanagerConstant.HYPHEN + KeymanagerConstant.COMPONENT_MASTER_KEY_DUMMY_REF; 
-		if(Objects.isNull(dbKeyStore)) {
-			dbKeyStore = dbHelper.getKeyAlias(certThumbprintHex, appIdRefIdKey, applicationId, referenceId);
-			cacheKeyStore.put(certThumbprintHex, dbKeyStore);
+		String compMasterKeyRefId = applicationId + KeymanagerConstant.HYPHEN + KeymanagerConstant.COMPONENT_MASTER_KEY_DUMMY_REF;
+
+		CacheEntry cacheEntry = cacheDecryptData.get(certThumbprintHex);
+		if (Objects.isNull(cacheEntry)) {
+			KeyStore dbKeyStore = dbHelper.getKeyAlias(certThumbprintHex, appIdRefIdKey, applicationId, referenceId);
 			// Added condition to handle issue related to decryption error with Master key.
-			if (Objects.isNull(dbKeyStore.getPrivateKey())) {
-				cacheReferenceIds.put(certThumbprintHex, compMasterKeyRefId);
-			} else {
-				cacheReferenceIds.put(certThumbprintHex, appIdRefIdKey);
-			}
+			String refIdToCache = Objects.isNull(dbKeyStore.getPrivateKey()) ? compMasterKeyRefId : appIdRefIdKey;
+			cacheEntry = new CacheEntry(dbKeyStore, refIdToCache);
+			cacheDecryptData.put(certThumbprintHex, cacheEntry);
 		}
 
-		String cachedRefId = cacheReferenceIds.getOrDefault(certThumbprintHex, null);
+		String cachedRefId = cacheEntry.refId;
 		if (!appIdRefIdKey.equals(cachedRefId) && !compMasterKeyRefId.equals(cachedRefId)){
-            LOGGER.error(KeymanagerConstant.SESSIONID, this.getClass().getSimpleName(), KeymanagerConstant.EMPTY,
-                "Application Id & Reference ID not matching with the input thumbprint value(decrypt).");
-            throw new KeymanagerServiceException(KeymanagerErrorConstant.APP_ID_REFERENCE_ID_NOT_MATCHING.getErrorCode(),
-                KeymanagerErrorConstant.APP_ID_REFERENCE_ID_NOT_MATCHING.getErrorMessage());
-        }
-        return dbKeyStore;
-    }
+			LOGGER.error(KeymanagerConstant.SESSIONID, this.getClass().getSimpleName(), KeymanagerConstant.EMPTY,
+					"Application Id & Reference ID not matching with the input thumbprint value(decrypt).");
+			throw new KeymanagerServiceException(KeymanagerErrorConstant.APP_ID_REFERENCE_ID_NOT_MATCHING.getErrorCode(),
+					KeymanagerErrorConstant.APP_ID_REFERENCE_ID_NOT_MATCHING.getErrorMessage());
+		}
+		return cacheEntry.keyStore;
+	}
 
-    public Object[] getKeyObjects(KeyStore dbKeyStore, boolean fetchMasterKey) {
-		
+	public Object[] getKeyObjects(KeyStore dbKeyStore, boolean fetchMasterKey) {
+
 		String ksAlias = dbKeyStore.getAlias();
 
 		String privateKeyObj = dbKeyStore.getPrivateKey();
 		if (Objects.isNull(privateKeyObj)) {
-            if (!fetchMasterKey) {
-                LOGGER.error(KeymanagerConstant.SESSIONID, KeymanagerConstant.APPLICATIONID, null,
-					"Not Allowed to perform decryption with the master key.");
-			    throw new KeymanagerServiceException(KeymanagerErrorConstant.DECRYPTION_NOT_ALLOWED.getErrorCode(),
-					KeymanagerErrorConstant.DECRYPTION_NOT_ALLOWED.getErrorMessage());
-            }
+			if (!fetchMasterKey) {
+				LOGGER.error(KeymanagerConstant.SESSIONID, KeymanagerConstant.APPLICATIONID, null,
+						"Not Allowed to perform decryption with the master key.");
+				throw new KeymanagerServiceException(KeymanagerErrorConstant.DECRYPTION_NOT_ALLOWED.getErrorCode(),
+						KeymanagerErrorConstant.DECRYPTION_NOT_ALLOWED.getErrorMessage());
+			}
 			LOGGER.info(KeymanagerConstant.SESSIONID, KeymanagerConstant.EMPTY, KeymanagerConstant.EMPTY,
 					"Private not found in key store. Getting private key from HSM.");
 			PrivateKeyEntry masterKeyEntry = keyStore.getAsymmetricKey(ksAlias);
@@ -119,8 +153,8 @@ public class PrivateKeyDecryptorHelper {
 		PrivateKey masterPrivateKey = masterKeyEntry.getPrivateKey();
 		PublicKey masterPublicKey = masterKeyEntry.getCertificate().getPublicKey();
 		try {
-			byte[] decryptedPrivateKey = keymanagerUtil.decryptKey(CryptoUtil.decodeURLSafeBase64(dbKeyStore.getPrivateKey()), 
-												masterPrivateKey, masterPublicKey);
+			byte[] decryptedPrivateKey = keymanagerUtil.decryptKey(CryptoUtil.decodeURLSafeBase64(dbKeyStore.getPrivateKey()),
+					masterPrivateKey, masterPublicKey);
 			KeyFactory keyFactory = KeyFactory.getInstance(KeymanagerConstant.RSA);
 			PrivateKey privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(decryptedPrivateKey));
 			Certificate certificate = keymanagerUtil.convertToCertificate(dbKeyStore.getCertificateData());


### PR DESCRIPTION
Performance & memory fixes

ReqResFilter.java — Capped ContentCachingRequestWrapper at 4 KB (was unbounded). Removed ContentCachingResponseWrapper entirely; the response now passes through directly. Controllers still read the full request stream — the cap only affects the in-memory log cache, and the MOSIP id/version fields always appear well within the first 4 KB.

ResponseBodyAdviceConfig.java — Moved objectMapper.registerModule(new JavaTimeModule()) to @PostConstruct. Previously called on every response (~150 allocations/sec at 150 RPS). Registration is idempotent, so once at startup is exactly equivalent.

PrivateKeyDecryptorHelper.java — Replaced two unbounded ConcurrentHashMaps (cacheKeyStore, cacheReferenceIds) with a single Cache2k cache (1440-min TTL, 1 000-entry LRU cap, ~3–5 MB max). keyStore and refId are merged into a single CacheEntry so they are always evicted atomically — this avoids a spurious APP_ID_REFERENCE_ID_NOT_MATCHING error that independent caches with separate LRU eviction would have caused. All DB fallback logic and validation are preserved verbatim.

CryptomanagerUtils.java — Promoted SecureRandom to private static final, seeded once at JVM startup. Previously instantiated per call (~150 OS-entropy seeds/sec). SecureRandom.nextBytes() is internally synchronized in the JCA implementation, so this is thread-safe across all Tomcat threads. The static final field survives @RefreshScope bean recreation by design.