### PR TITLE
MOSIP-44250: allow expired certificate to verify jwt sign (#513)

### DIFF
--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/signature/service/impl/SignatureServiceImpl.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/signature/service/impl/SignatureServiceImpl.java
@@ -617,13 +617,13 @@ public class SignatureServiceImpl implements SignatureService, SignatureServicev
 		JsonWebSignature jws = new JsonWebSignature();
 		try {
 			X509Certificate x509CertToVerify = (X509Certificate) certToVerify;
-			boolean validCert = SignatureUtil.isCertificateDatesValid(x509CertToVerify);
-			if (!validCert) {
-				// LOGGER.error(SignatureConstant.SESSIONID, SignatureConstant.JWT_SIGN, SignatureConstant.BLANK,
-				// 	"Error certificate dates are not valid.");
+//			boolean validCert = SignatureUtil.isCertificateDatesValid(x509CertToVerify);
+//			if (!validCert) {
+//				 LOGGER.error(SignatureConstant.SESSIONID, SignatureConstant.JWT_SIGN, SignatureConstant.BLANK,
+//				 	"Error certificate dates are not valid.");
 //					throw new CertificateNotValidException(SignatureErrorCode.CERT_NOT_VALID.getErrorCode(),
 //								SignatureErrorCode.CERT_NOT_VALID.getErrorMessage());
-			}
+//			}
 
 			String keyAlgorithm = x509CertToVerify.getPublicKey().getAlgorithm();
 			PublicKey publicKey = null;

--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/signature/service/impl/SignatureServiceImpl.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/signature/service/impl/SignatureServiceImpl.java
@@ -619,10 +619,10 @@ public class SignatureServiceImpl implements SignatureService, SignatureServicev
 			X509Certificate x509CertToVerify = (X509Certificate) certToVerify;
 			boolean validCert = SignatureUtil.isCertificateDatesValid(x509CertToVerify);
 			if (!validCert) {
-				LOGGER.error(SignatureConstant.SESSIONID, SignatureConstant.JWT_SIGN, SignatureConstant.BLANK,
-					"Error certificate dates are not valid.");
-					throw new CertificateNotValidException(SignatureErrorCode.CERT_NOT_VALID.getErrorCode(),
-								SignatureErrorCode.CERT_NOT_VALID.getErrorMessage());
+				// LOGGER.error(SignatureConstant.SESSIONID, SignatureConstant.JWT_SIGN, SignatureConstant.BLANK,
+				// 	"Error certificate dates are not valid.");
+//					throw new CertificateNotValidException(SignatureErrorCode.CERT_NOT_VALID.getErrorCode(),
+//								SignatureErrorCode.CERT_NOT_VALID.getErrorMessage());
 			}
 
 			String keyAlgorithm = x509CertToVerify.getPublicKey().getAlgorithm();

--- a/kernel/kernel-keymanager-service/src/test/java/io/mosip/kernel/crypto/jce/test/CryptoCoreNoSuchAlgorithmExceptionTest.java
+++ b/kernel/kernel-keymanager-service/src/test/java/io/mosip/kernel/crypto/jce/test/CryptoCoreNoSuchAlgorithmExceptionTest.java
@@ -27,6 +27,7 @@ import io.mosip.kernel.core.crypto.spi.CryptoCoreSpec;
 import io.mosip.kernel.core.exception.NoSuchAlgorithmException;
 
 @RunWith(SpringRunner.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @SpringBootTest
 public class CryptoCoreNoSuchAlgorithmExceptionTest {

--- a/kernel/kernel-keymanager-service/src/test/java/io/mosip/kernel/crypto/jce/test/CryptoCoreNoSuchAlgorithmExceptionTest.java
+++ b/kernel/kernel-keymanager-service/src/test/java/io/mosip/kernel/crypto/jce/test/CryptoCoreNoSuchAlgorithmExceptionTest.java
@@ -27,8 +27,7 @@ import io.mosip.kernel.core.crypto.spi.CryptoCoreSpec;
 import io.mosip.kernel.core.exception.NoSuchAlgorithmException;
 
 @RunWith(SpringRunner.class)
-@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
-@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest
 public class CryptoCoreNoSuchAlgorithmExceptionTest {
 


### PR DESCRIPTION
* MOSIP-44250: allow expired certifivate to verify jwt sign



* MOSIP-44250: Disable error logging for certificate date validation

Comment out error logging for invalid certificate dates.



---------